### PR TITLE
Fix chatbot placement

### DIFF
--- a/themes/toha/layouts/index.html
+++ b/themes/toha/layouts/index.html
@@ -25,9 +25,6 @@
     <!-- Chat Component -->
     <script src="{{ "js/chat.js" | relURL }}"></script>
     <link rel="stylesheet" href="{{ "js/chat.css" | relURL }}">
-
-    <!-- Chat Root Element -->
-    <div id="chat-root" style="position: relative; z-index: 1000;"></div>
   </head>
   <body data-bs-spy="scroll" data-bs-target="#top-navbar" data-bs-offset="100">
 
@@ -73,6 +70,9 @@
 
     <!------ ADD SUPPORT LINKS -------->
     {{- partial "misc/support.html" . -}}
+
+    <!-- Chat Root Element -->
+    <div id="chat-root" style="position: relative; z-index: 1000;"></div>
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move chatbot container from `<head>` into the document body

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684476030380832382dab056c6fd9069