### PR TITLE
Fix chatbot placement

### DIFF
--- a/themes/toha/layouts/index.html
+++ b/themes/toha/layouts/index.html
@@ -24,10 +24,6 @@
 
     <!-- Chat Component -->
     <script src="{{ "js/chat.js" | relURL }}"></script>
-    <link rel="stylesheet" href="{{ "js/chat.css" | relURL }}">
-
-    <!-- Chat Root Element -->
-    <div id="chat-root" style="position: relative; z-index: 1000;"></div>
   </head>
   <body data-bs-spy="scroll" data-bs-target="#top-navbar" data-bs-offset="100">
 
@@ -73,6 +69,9 @@
 
     <!------ ADD SUPPORT LINKS -------->
     {{- partial "misc/support.html" . -}}
+
+    <!-- Chat Root Element -->
+    <div id="chat-root" style="position: relative; z-index: 1000;"></div>
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move chatbot container to end of body
- drop reference to missing chat.css file

## Testing
- `npm --prefix src run build`
- `hugo --gc --minify` *(fails: requires Hugo >=0.146 with Sass support)*

------
https://chatgpt.com/codex/tasks/task_e_684476030380832382dab056c6fd9069