### PR TITLE
Fix chat widget location without modifying theme

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}">
+  <head>
+    <title>{{ .Page.Title }}</title>
+    <!------ ADD COMMON HEADERS -------->
+    {{- partial "header.html" . -}}
+    {{- partial "opengraph.html" . -}}
+    <!------ ADD PAGE SPECIFIC HEADERS ------->
+    {{ block "header" . }} {{ end }}
+
+    <!--================= add analytics if enabled =========================-->
+    {{- partial "analytics.html" . -}}
+    {{ with resources.Get "scripts/core/theme-scheme.js" | fingerprint }}
+    <script integrity="{{.Data.Integrity}}">
+     {{ .Content | safeJS }}
+    </script>
+    {{ end }}
+    <script src="{{ "js/chat.js" | relURL }}"></script>
+  </head>
+
+  <body class="type-{{ .Page.Type }} kind-{{ .Page.Kind }}" data-bs-spy="scroll" data-bs-target="#TableOfContents" data-bs-offset="80">
+    <div class="container-fluid bg-secondary wrapper">
+      <!----- ADD NAVBAR --------------->
+      {{ block "navbar" . }} {{ end }}
+
+      <!----- ADD SIDEBAR --------------->
+      {{ block "sidebar" . }} {{ end }}
+
+      <!----- ADD PAGE CONTENT --------->
+      {{ block "content" . }} {{ end }}
+
+      <!----- ADD TABLE OF CONTENTS ----------->
+      {{ block "toc" . }} {{ end }}
+    </div>
+
+    <!------- ADD FOOTER ------------>
+    {{ $footerTemplate:= site.Params.footer.template | default "footer.html" }}
+    {{- partial $footerTemplate . -}}
+
+    <!------- ADD COMMON SCRIPTS ------->
+    {{ partial "scripts.html" . }}
+
+    <!------- ADD PAGE SPECIFIC SCRIPTS ------>
+    {{ block "scripts" . }} {{ end }}
+
+    <!------ IF WANTED, ADD SUPPORT LINKS -------->
+    {{- partial "misc/support.html" . -}}
+
+    <div id="chat-root" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999;"></div>
+
+  </body>
+</html>

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1,0 +1,39 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const root = document.getElementById("chat-root");
+  if (!root) return;
+
+  root.innerHTML = `
+    <div id="chat-launcher">💬 Questions about my experience?</div>
+    <div id="chat-box" style="display: none;">
+      <div id="chat-log"></div>
+      <input id="chat-input" placeholder="Ask me something..." onkeydown="if(event.key==='Enter'){sendMessage()}" />
+    </div>
+  `;
+
+  document.getElementById("chat-launcher").onclick = () => {
+    const box = document.getElementById("chat-box");
+    box.style.display = box.style.display === "none" ? "block" : "none";
+  };
+});
+
+async function sendMessage() {
+  const input = document.getElementById("chat-input");
+  const log = document.getElementById("chat-log");
+  const userMessage = input.value;
+  if (!userMessage) return;
+
+  log.innerHTML += `<div><strong>You:</strong> ${userMessage}</div>`;
+  input.value = "";
+
+  try {
+    const res = await fetch("https://<your-backend>.onrender.com/ask", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: userMessage })
+    });
+    const data = await res.json();
+    log.innerHTML += `<div><strong>Bot:</strong> ${data.answer}</div>`;
+  } catch (err) {
+    log.innerHTML += `<div><strong>Bot:</strong> Sorry, something went wrong. (${err.message})</div>`;
+  }
+}

--- a/themes/toha/layouts/index.html
+++ b/themes/toha/layouts/index.html
@@ -22,12 +22,6 @@
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
 
-    <!-- Chat Component -->
-    <script src="{{ "js/chat.js" | relURL }}"></script>
-    <link rel="stylesheet" href="{{ "js/chat.css" | relURL }}">
-
-    <!-- Chat Root Element -->
-    <div id="chat-root" style="position: relative; z-index: 1000;"></div>
   </head>
   <body data-bs-spy="scroll" data-bs-target="#top-navbar" data-bs-offset="100">
 
@@ -73,6 +67,7 @@
 
     <!------ ADD SUPPORT LINKS -------->
     {{- partial "misc/support.html" . -}}
+
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- copy Toha base template into project layout and inject chat widget
- remove chat widget additions from the theme's template

## Testing
- `npm --prefix src run build` *(fails: vite not found)*
- `hugo --gc --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684476030380832382dab056c6fd9069